### PR TITLE
ci: Update test runner from macOS to Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.12]


### PR DESCRIPTION
Changed the CI test job to use ubuntu-latest instead of macos-latest for improved build speed and cost efficiency.

🤖 Generated with [Claude Code](https://claude.ai/code)