### PR TITLE
fix: unify to uv-only workflow; remove pip instructions (Closes #35)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,17 +10,17 @@
 - `ffmpeg_processor.py`: Optional FFmpeg-based noise reduction and filters.
 - `whisper_models.py`: Local model metadata and management helpers.
 - `tests/`: Pytest suite (`test_*.py`).
-- Tooling: `pyproject.toml` (deps, ruff, pytest, mypy), `Makefile` (dev workflow), `.env.local` (secrets), `requirements.txt` (legacy/pip).
+- Tooling: `pyproject.toml` (deps, ruff, pytest, mypy), `Makefile` (dev workflow), `.env.local` (secrets).
 
 ## Build, Test, and Development Commands
 - `make dev-setup`: Sync deps (via `uv`); sets up dev env.
-- `make run` / `make run-pip`: Launch app with `uv` or system/pip env.
+- `make run`: Launch app with `uv`.
 - `make test`: Run pytest with coverage (term + xml + htmlcov).
 - `make lint` / `make lint-check`: Ruff lint/format (fix vs. check-only).
 - `make format`: Apply ruff formatter.
 - `make security`: Ruff security rules + `pip-audit`.
 - `make check`: Lockfile check, quality, tests.
-- Alternatives: `uv sync`, `uv run pytest -v`, or `make pip-*` targets.
+- Alternatives: `uv sync`, `uv run pytest -v`.
 
 ## Coding Style & Naming Conventions
 - Python 3.9+, 4-space indent, max line length 88, double quotes (ruff formatter).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,22 +85,21 @@ gh pr create
 - **HTTP Requests**: `requests` (for model downloading)
 - **Audio Processing**: `numpy`, `scipy`
 
-## Development Setup
+## Development Setup (uv)
 
 ```bash
-# Create virtual environment
-python3 -m venv venv
-source venv/bin/activate
+# Install uv (if not installed)
+curl -LsSf https://astral.sh/uv/install.sh | sh
 
-# Install dependencies
-pip install -r requirements.txt
+# Sync dependencies
+uv sync
 
 # Create environment configuration
 echo "OPENAI_API_KEY=your-openai-api-key-here" > .env.local
 echo "SPEECH_PROVIDER=openai" >> .env.local
 
 # Run the application
-python termina.py
+uv run python termina.py
 ```
 
 ### Environment Configuration
@@ -150,7 +149,7 @@ The application follows this workflow:
 
 ## Dependencies
 
-See `requirements.txt` for the complete list. Key dependencies include:
+See `pyproject.toml` for the complete list. Key dependencies include:
 
 ```
 rumps>=0.4.0                 # macOS menu bar UI

--- a/Makefile
+++ b/Makefile
@@ -22,29 +22,19 @@ lock: ## Update lock file
 lock-check: ## Verify lock file is up to date
 	uv lock --check
 
-# Alternative pip-based installation (legacy)
-pip-install: ## Install dependencies using pip (fallback)
-	python -m pip install --upgrade pip
-	pip install -r requirements.txt
-
-pip-dev-install: ## Install development dependencies using pip (fallback)
-	python -m pip install --upgrade pip
-	pip install -r requirements.txt
-	pip install pytest pytest-cov ruff mypy pip-audit
+## NOTE: pip ベースの手順は廃止しました。uv に一本化しています。
 
 # Runtime commands
 run: ## Run the application
 	uv run python termina.py
 
-run-pip: ## Run the application using pip environment
-	python termina.py
+## NOTE: pip ベースの手順は廃止しました。uv に一本化しています。
 
 # Development and testing
 test: ## Run tests with coverage
 	uv run pytest --cov=. --cov-report=term-missing --cov-report=html
 
-test-pip: ## Run tests with coverage using pip
-	pytest --cov=. --cov-report=term-missing --cov-report=html
+## NOTE: pip ベースの手順は廃止しました。uv に一本化しています。
 
 # Code quality checks
 lint: ## Run ruff linter and formatter (recommended order)
@@ -106,10 +96,4 @@ quick-test: ## Run tests without coverage
 ci: check ## Alias for check - comprehensive CI pipeline
 	@echo "✅ CI checks completed!"
 
-# pip-based alternatives (legacy compatibility)
-pip-quality: ## Run quality checks using pip environment
-	ruff check .
-	ruff format --check .
-	ruff check --select=S .
-	pip-audit
-	@echo "ℹ️  Note: mypy type checking is disabled due to unresolved errors"
+## NOTE: pip ベースの手順は廃止しました。uv に一本化しています。

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ TerminaはPythonで作られたmacOSのメニューバー常駐アプリです�
 
 機能構成	使用技術
 使用言語	Python 3.9以上
-パッケージ管理	uv (推奨) または pip
+パッケージ管理	uv（サポート対象）
 メニューバーUI	rumps
 音声録音	sounddevice, scipy.io.wavfile
 音声認識	OpenAI Whisper API（openaiライブラリ）
@@ -34,7 +34,7 @@ TerminaはPythonで作られたmacOSのメニューバー常駐アプリです�
 ### 前提条件
 - macOS 10.14以上
 - Python 3.9以上
-- uv（推奨パッケージマネージャー） または pip
+- uv（推奨パッケージマネージャー）
 - OpenAI APIキー（[OpenAI Platform](https://platform.openai.com/)で取得）
 - FFmpeg（音声前処理用、任意）
 - マイクアクセス許可
@@ -46,7 +46,7 @@ TerminaはPythonで作られたmacOSのメニューバー常駐アプリです�
 brew install ffmpeg
 ```
 
-### インストール手順
+### インストール手順（uv）
 
 1. **リポジトリをクローン**
 ```bash
@@ -65,13 +65,7 @@ brew install uv
 
 3. **依存関係をインストール**
 ```bash
-# uvを使用（推奨 - 高速でモダン）
 uv sync
-
-# または従来のpipを使用
-python3 -m venv venv
-source venv/bin/activate
-pip install -r requirements.txt
 ```
 
 4. **音声認識プロバイダーを設定**
@@ -95,11 +89,7 @@ SPEECH_PROVIDER=openai
 
 5. **アプリを実行**
 ```bash
-# uvを使用する場合
 uv run python termina.py
-
-# または従来の方法
-python termina.py
 ```
 
 ### ローカルWhisper（オフライン音声認識）の使用
@@ -108,11 +98,7 @@ python termina.py
 
 1. **openai-whisperをインストール**
 ```bash
-# uvを使用する場合（推奨）
 uv add openai-whisper
-
-# または従来のpipを使用
-pip install openai-whisper
 ```
 
 2. **設定ファイルを更新**
@@ -225,17 +211,8 @@ make check
 make help
 ```
 
-### 従来のpip環境での開発
-```bash
-# 依存関係をインストール
-make pip-dev-install
-
-# アプリを実行
-make run-pip
-
-# 品質チェック
-make pip-quality
-```
+### 開発はuvで行います
+uv を使ったワークフローのみサポートします（pip 手順は廃止）。
 
 🧠 今後の改善予定
 	•	⚙️ ホットキーのカスタマイズ機能

--- a/termina.py
+++ b/termina.py
@@ -563,7 +563,7 @@ def main():
                 "No speech recognition providers available.\n\n"
                 "Please configure:\n"
                 "• OpenAI API: Set OPENAI_API_KEY in .env.local\n"
-                "• Local Whisper: Run 'pip install openai-whisper'",
+                "• Local Whisper: Run 'uv add openai-whisper'",
             )
             return
 


### PR DESCRIPTION
Issue #35 を解決し、uv に一本化しました。\n\n- Makefile から pip 系ターゲットを削除\n- README を uv 手順のみに更新\n- AGENTS.md/CLAUDE.md から requirements.txt/pip 記述を削除\n- アプリ内のメッセージを 'uv add openai-whisper' に更新\n\nテスト: make test (6 passed)。レビューお願いします。